### PR TITLE
Put Original max z position K2 Neo

### DIFF
--- a/Kobra2Neo/cfg/k2neo_Xenyonmedia_v201.cfg
+++ b/Kobra2Neo/cfg/k2neo_Xenyonmedia_v201.cfg
@@ -85,7 +85,7 @@ microsteps: 16
 rotation_distance: 8
 endstop_pin: probe:z_virtual_endstop
 position_min: -2
-position_max: 200
+position_max: 250
 homing_speed: 15
 second_homing_speed: 2
 


### PR DESCRIPTION
I was printing a tall object and fail because, first of all my error on not looking that, the z max pos was wrong. The k2 neo has a max z height of 250.